### PR TITLE
Made it work under python3 BUT python2 now returns an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A parser for Japanese number (Kanji, arabic) in the natural language.
 
-Japanese-numbers finds any numbers in the natural language, and convert to arabic.
-The followings are an example patterns what can be parsed.
+The module **japanese_numbers** finds any numbers in the natural language, and converts to arabic numerals.
+The followings are example patterns what can be parsed.
 
 - 二千万百一円
 - 5百万
@@ -17,7 +17,7 @@ Currently, you can install from PYPI by using pip:
 
     pip2 install japanese-numbers-python
 
-Or installing github directly:
+Or installing github directly, with Python3 support:
 
     pip3 install git+git://github.com/SteveClement/japanese-numbers-python.git
 
@@ -71,7 +71,7 @@ japanese_numbers.to_arabic_numbers('一を聞いて十を知る。')
 - support negative types
 
 
-### Patch
+### Patches
 
 Welcome!
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The followings are an example patterns what can be parsed.
 
 Currently, you can install from PYPI by using pip:
 
-    pip install japanses-numbers-python
+    pip2 install japanese-numbers-python
 
 Or installing github directly:
 
-    pip install git+git://github.com/takumakanari/japanses-numbers-python.git
+    pip3 install git+git://github.com/SteveClement/japanese-numbers-python.git
 
 
 ## Usage

--- a/japanese_numbers/__init__.py
+++ b/japanese_numbers/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 

--- a/japanese_numbers/__init__.py
+++ b/japanese_numbers/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import
+
 
 from japanese_numbers.parser.to_arabic_parser import (  # noqa
   to_arabic,

--- a/japanese_numbers/__init__.py
+++ b/japanese_numbers/__init__.py
@@ -8,8 +8,8 @@ from japanese_numbers.parser.to_arabic_parser import (  # noqa
 )
 
 __japanese_numbers__ = 'japanese-numbers-python'
-__version__ = '0.1.0'
-__author__ = 'Takumakanari'
+__version__ = '0.1.1'
+__author__ = 'Takumakanari, @SteveClement'
 __license__ = 'MIT'
 __description__ = 'A parser for Japanese number (Kanji, arabic) in the natulal language.'  # noqa
 

--- a/japanese_numbers/kind.py
+++ b/japanese_numbers/kind.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 
-
+# Various kinds of unit
 UNIT_KIND = 'JU'
 NUMBERS_KIND = 'JN'
 MULTIPLES_KIND = 'JM'

--- a/japanese_numbers/kind.py
+++ b/japanese_numbers/kind.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+
 
 
 UNIT_KIND = 'JU'

--- a/japanese_numbers/parser/__init__.py
+++ b/japanese_numbers/parser/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import
+
 

--- a/japanese_numbers/parser/to_arabic_parser.py
+++ b/japanese_numbers/parser/to_arabic_parser.py
@@ -12,21 +12,17 @@ from japanese_numbers.kind import (  # noqa
 )
 
 
-def _each(values):
-  s = len(values)
+def _collect_numerics(token):
+  stack, pos_size, values = ([], 0, token.val[token.pos:])
+  size = len(values)
   for i, c in enumerate(values):
-    nc = values[i + 1] if i + 1 < s else None
-    yield (c, nc)
-
-
-def _collect_numerics(val, pos):
-  stack, pos_size = ([], 0)
-  for c, nc in _each(val[pos:]):
-    comma = c == ','
     if c not in NUMERICS:
-      if not comma or nc not in NUMERICS:
+      comma = c == ','
+      nc_org = token.origin_char_at(token.pos + i + 1) \
+        if i + 1 < size else None
+      if not comma or nc_org not in NUMERICS:
         break
-    if not comma:
+    else:
       stack.append(c)
     pos_size += 1
   return int(''.join(stack)), pos_size
@@ -61,7 +57,7 @@ def to_arabic(val):
       numbers = []
 
     elif kind == NUMERIC_KIND:
-      n, s = _collect_numerics(token.val, token.pos)
+      n, s = _collect_numerics(token)
       numbers.append(n)
       index = token.pos if index < 0 else index
       texts.append(''.join(token.origin_char_at(x)

--- a/japanese_numbers/parser/to_arabic_parser.py
+++ b/japanese_numbers/parser/to_arabic_parser.py
@@ -12,13 +12,24 @@ from japanese_numbers.kind import (  # noqa
 )
 
 
+def _each(values):
+  s = len(values)
+  for i, c in enumerate(values):
+    nc = values[i + 1] if i + 1 < s else None
+    yield (c, nc)
+
+
 def _collect_numerics(val, pos):
-  stack = []
-  for c in val[pos:]:
+  stack, pos_size = ([], 0)
+  for c, nc in _each(val[pos:]):
+    comma = c == ','
     if c not in NUMERICS:
-      break
-    stack.append(c)
-  return int(''.join(stack)), len(stack)
+      if not comma or nc not in NUMERICS:
+        break
+    if not comma:
+      stack.append(c)
+    pos_size += 1
+  return int(''.join(stack)), pos_size
 
 
 def to_arabic(val):

--- a/japanese_numbers/parser/to_arabic_parser.py
+++ b/japanese_numbers/parser/to_arabic_parser.py
@@ -11,8 +11,6 @@ from japanese_numbers.kind import (  # noqa
   NUMERIC_KIND
 )
 
-DEBUG = True
-
 def _collect_numerics(token):
   stack, pos_size, values = ([], 0, token.val[token.pos:])
   size = len(values)
@@ -34,20 +32,11 @@ def to_arabic(val):
   results = []
 
   def _append_result():
-    results.append(ParsedResult(text=''.join(texts),
-                                number=sum(stacks) + sum(numbers),
-                                index=index))
+    results.append(ParsedResult(text   = ''.join(texts),
+                                number = sum(stacks) + sum(numbers),
+                                index  = index))
 
   token = Tokenized(val)
-  if DEBUG:
-      import pprint
-      pp = pprint.PrettyPrinter(indent=4)
-      print('''Instantiating token: Tokenized({})
-
-        '''.format(val))
-      print('dir() of token: {}'.format(pp.pprint(dir(token))))
-      print('Token _size: {}'.format(token._size))
-
   # Main loop to get all the tokens from the class
   while token.has_next():
     # Get kind and the number of kind

--- a/japanese_numbers/parser/to_arabic_parser.py
+++ b/japanese_numbers/parser/to_arabic_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 
@@ -11,6 +11,7 @@ from japanese_numbers.kind import (  # noqa
   NUMERIC_KIND
 )
 
+DEBUG = True
 
 def _collect_numerics(val, pos):
   stack = []
@@ -31,8 +32,18 @@ def to_arabic(val):
                                 index=index))
 
   token = Tokenized(val)
+  if DEBUG:
+      import pprint
+      pp = pprint.PrettyPrinter(indent=4)
+      print('''Instantiating token: Tokenized({})
 
+        '''.format(val))
+      print('dir() of token: {}'.format(pp.pprint(dir(token))))
+      print('Token _size: {}'.format(token._size))
+
+  # Main loop to get all the tokens from the class
   while token.has_next():
+    # Get kind and the number of kind
     kind, num = (token.kind, token.num_of_kind)
 
     if kind == UNIT_KIND and token.last_kind != UNIT_KIND:
@@ -55,7 +66,7 @@ def to_arabic(val):
       index = token.pos if index < 0 else index
       texts.append(''.join(token.origin_char_at(x)
                    for x in range(token.pos, token.pos + s)))
-      token.next(incr=s)
+      token.next()
 
     elif analyzing:
       _append_result()
@@ -70,7 +81,7 @@ def to_arabic(val):
         index = token.pos
 
     if kind != NUMERIC_KIND:
-      next(token)
+      token.next()
 
   if stacks or numbers:
     _append_result()

--- a/japanese_numbers/parser/to_arabic_parser.py
+++ b/japanese_numbers/parser/to_arabic_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+
 
 from japanese_numbers.result import ParsedResult
 from japanese_numbers.token import Tokenized, NUMERICS
@@ -54,7 +54,7 @@ def to_arabic(val):
       numbers.append(n)
       index = token.pos if index < 0 else index
       texts.append(''.join(token.origin_char_at(x)
-                   for x in xrange(token.pos, token.pos + s)))
+                   for x in range(token.pos, token.pos + s)))
       token.next(incr=s)
 
     elif analyzing:
@@ -70,7 +70,7 @@ def to_arabic(val):
         index = token.pos
 
     if kind != NUMERIC_KIND:
-      token.next()
+      next(token)
 
   if stacks or numbers:
     _append_result()

--- a/japanese_numbers/result.py
+++ b/japanese_numbers/result.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+
 
 
 class ParsedResult(object):

--- a/japanese_numbers/result.py
+++ b/japanese_numbers/result.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
-
+import six
 
 class ParsedResult(object):
 
   def __init__(self, text=None, number=None, type=int, index=-1):
-    self.text = text
+    self.text   = text
     self.number = number
-    self.type = type
-    self.index = index
+    self.type   = type
+    self.index  = index
 
   def __repr__(self):
+    # __repr__ always returns a string type. We don't want to return bytes, thus we use six in __str__()
     return self.__str__()
 
   def __str__(self):
-    return '<{0} {1[number]} : "{1[text]}" index={1[index]}>'. \
+    # Consider python2 ppl, because easy to implement, for the rest, please use py3
+    # See -> https://pythonclock.org/
+    if six.PY2:
+      return '<{0} {1[number]} : "{1[text]}" index={1[index]}>'. \
            format(self.__class__.__name__, self.__dict__).encode('utf8')
+    return '<{0} {1[number]} : "{1[text]}" index={1[index]}>'. \
+           format(self.__class__.__name__, self.__dict__)

--- a/japanese_numbers/result.py
+++ b/japanese_numbers/result.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 

--- a/japanese_numbers/token.py
+++ b/japanese_numbers/token.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+
 
 from japanese_numbers.kind import (  # noqa
   UNIT_KIND,
@@ -27,7 +27,7 @@ NUMBERS = {  # noqa
   for x in enumerate(('一', '二', '三', '四', '五', '六', '七', '八', '九', '十'))
 }
 
-NUMERICS = map(str, xrange(0, 10))
+NUMERICS = list(map(str, range(0, 10)))
 
 TRANSLATE_NUMBERS = {  # noqa
   x[1]: x[0]
@@ -79,7 +79,7 @@ class Tokenized(object):
   @classmethod
   def _convert_kanji_to_arabic(cls, val):
     val_ = val
-    for src, dest in TRANSLATE_NUMBERS.items():
+    for src, dest in list(TRANSLATE_NUMBERS.items()):
       val_ = val_.replace(src, str(dest))
     return val_
 

--- a/japanese_numbers/token.py
+++ b/japanese_numbers/token.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 
@@ -46,6 +46,12 @@ class Tokenized(object):
     self.char = None
     self.pos = -1
     self.last_kind = None
+
+  def __iter__(self):
+    return self.pos <= self._size - 1
+
+  def __next__(self, incr=1):
+    return
 
   def next(self, incr=1):
     self.pos += incr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+six ; python_version < '2.7*'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import
+
 
 from nose.tools import ok_
 from nose.tools import eq_

--- a/tests/test_to_arabic_parser.py
+++ b/tests/test_to_arabic_parser.py
@@ -56,13 +56,16 @@ class Test_to_arabic(TestCase):
     compare_result(ret[1], R(number=50000, text='50,000', index=24))
 
   def test_kanji_with_comma(self):
-    # FIXME test failure
     ret = to_arabic('二,三,四')
-    print ret
     eq_(len(ret), 3)
     compare_result(ret[0], R(number=2, text='二', index=0))
     compare_result(ret[1], R(number=3, text='三', index=2))
     compare_result(ret[2], R(number=4, text='四', index=4))
+
+    ret = to_arabic('テスト、二三四,十一')
+    eq_(len(ret), 2)
+    compare_result(ret[0], R(number=234, text='二三四', index=4))
+    compare_result(ret[1], R(number=11, text='十一', index=8))
 
   def test_kanji_only_10(self):
     ret = to_arabic('十一')

--- a/tests/test_to_arabic_parser.py
+++ b/tests/test_to_arabic_parser.py
@@ -45,6 +45,25 @@ class Test_to_arabic(TestCase):
     compare_result(ret[0], R(number=1, text='1', index=0))
     compare_result(ret[1], R(number=10, text='10', index=5))
 
+  def test_numeric_with_comma(self):
+    ret = to_arabic('10,000円')
+    eq_(len(ret), 1)
+    compare_result(ret[0], R(number=10000, text='10,000', index=0))
+
+    ret = to_arabic('abc, 10,000,000,円, edf, 50,000,')
+    eq_(len(ret), 2)
+    compare_result(ret[0], R(number=10000000, text='10,000,000', index=5))
+    compare_result(ret[1], R(number=50000, text='50,000', index=24))
+
+  def test_kanji_with_comma(self):
+    # FIXME test failure
+    ret = to_arabic('二,三,四')
+    print ret
+    eq_(len(ret), 3)
+    compare_result(ret[0], R(number=2, text='二', index=0))
+    compare_result(ret[1], R(number=3, text='三', index=2))
+    compare_result(ret[2], R(number=4, text='四', index=4))
+
   def test_kanji_only_10(self):
     ret = to_arabic('十一')
     eq_(len(ret), 1)

--- a/tests/test_to_arabic_parser.py
+++ b/tests/test_to_arabic_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- encoding:utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+
 
 from unittest import TestCase
 from nose.tools import eq_

--- a/tests/test_to_arabic_parser.py
+++ b/tests/test_to_arabic_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding:utf-8 -*-
 
 


### PR DESCRIPTION
Dear,

I ported it to python3 but broke python 2 support :(

Obviously no good for you, nevertheless I create a pull request in case you have a quick fix.

Feel free to reject, of course.

This is a, it works for me situation.

Thanks for the initial efforts.

$ python2
Python 2.7.14 (default, Oct 12 2017, 18:39:18)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import japanese_numbers
>>>
>>> japanese_numbers.to_arabic_numbers('一を聞いて十を知る。')
(1,)
>>> japanese_numbers.to_arabic('銀河の向こう、六千三百二十一億千五百十一万二千百八十一光年彼方。')
[Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/japanese_numbers/result.py", line 16, in __repr__
    return self.__str__()
  File "/usr/local/lib/python2.7/site-packages/japanese_numbers/result.py", line 23, in __str__
    format(self.__class__.__name__, self.__dict__).encode('utf8')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 19: ordinal not in range(128)